### PR TITLE
track number of connections per pool, enforce max limit if specified

### DIFF
--- a/include/grpcbox.hrl
+++ b/include/grpcbox.hrl
@@ -34,3 +34,5 @@
 
 -define(GRPC_ERROR(Status, Message), {grpc_error, {Status, Message}}).
 -define(THROW(Status, Message), throw(?GRPC_ERROR(Status, Message))).
+
+-define(ACTIVE_CONNS_PER_POOL_TABLE, active_conns_per_pool_table).

--- a/src/grpcbox_acceptor.erl
+++ b/src/grpcbox_acceptor.erl
@@ -6,23 +6,46 @@
          acceptor_continue/3,
          acceptor_terminate/2]).
 
-acceptor_init(_, LSocket, {Transport, ServerOpts, ChatterboxOpts, SslOpts}) ->
+acceptor_init(_, LSocket, {PoolName, Transport, ServerOpts, ChatterboxOpts, SslOpts}) ->
     % monitor listen socket to gracefully close when it closes
     MRef = monitor(port, LSocket),
-    {ok, {Transport, MRef, ServerOpts, ChatterboxOpts, SslOpts}}.
+    {ok, {Transport, MRef, PoolName, ServerOpts, ChatterboxOpts, SslOpts}}.
 
-acceptor_continue(_PeerName, Socket, {ssl, _MRef, ServerOpts, ChatterboxOpts, SslOpts}) ->
+acceptor_continue(_PeerName, Socket, {ssl, _MRef, PoolName, ServerOpts, ChatterboxOpts, SslOpts}) ->
     {ok, AcceptSocket} = ssl:handshake(Socket, SslOpts),
     case ssl:negotiated_protocol(AcceptSocket) of
         {ok, <<"h2">>} ->
-            h2_connection:become({ssl, AcceptSocket}, ServerOpts, ChatterboxOpts);
+            %% get the max connection settings from the grpcbox config
+            %% default to unlimited if not specified
+            MaxConns = maps:get(max_connections, ServerOpts, unlimited),
+            case connection_allowed(PoolName, MaxConns) of
+                true ->
+                    h2_connection:become({ssl, AcceptSocket}, chatterbox:settings(server, ServerOpts), ChatterboxOpts),
+                    _ = grpcbox_pool:inc_conn_count(PoolName);
+                false ->
+                    exit(max_connections_exceeded)
+            end;
         _ ->
             exit(bad_negotiated_protocol)
     end;
-acceptor_continue(_PeerName, Socket, {gen_tcp, _MRef, ServerOpts, ChatterboxOpts, _SslOpts}) ->
-    h2_connection:become({gen_tcp, Socket}, ServerOpts, ChatterboxOpts).
 
-acceptor_terminate(Reason, _) ->
+acceptor_continue(_PeerName, Socket, {gen_tcp, _MRef, PoolName, ServerOpts, ChatterboxOpts, _SslOpts}) ->
+    MaxConns = maps:get(max_connections, ServerOpts, unlimited),
+    case connection_allowed(PoolName, MaxConns) of
+        true ->
+            h2_connection:become({gen_tcp, Socket}, chatterbox:settings(server, ServerOpts), ChatterboxOpts),
+            _ = grpcbox_pool:inc_conn_count(PoolName);
+        false ->
+            exit(max_connections_exceeded)
+    end.
+
+acceptor_terminate(Reason, {_, _MRef, PoolName, _ServerOpts, _ChatterboxOpts, _SslOpts}) ->
     % Something went wrong. Either the acceptor_pool is terminating or the
     % accept failed.
+    _ = grpcbox_pool:dec_conn_count(PoolName),
     exit(Reason).
+
+connection_allowed(_PoolName, unlimited) ->
+    true;
+connection_allowed(PoolName, MaxConns) ->
+    grpcbox_pool:connection_count(PoolName) =< MaxConns.

--- a/src/grpcbox_pool.erl
+++ b/src/grpcbox_pool.erl
@@ -1,15 +1,20 @@
 -module(grpcbox_pool).
+-include("grpcbox.hrl").
 
 -behaviour(acceptor_pool).
 
 -export([start_link/4,
          accept_socket/3,
-         pool_sockets/1]).
+         pool_sockets/1,
+         connection_count/1,
+         inc_conn_count/1,
+         dec_conn_count/1]).
 
 -export([init/1]).
 
-start_link(Name, ServerOpts, ChatterboxOpts, TransportOpts) ->
-    acceptor_pool:start_link({local, Name}, ?MODULE, [ServerOpts, ChatterboxOpts, TransportOpts]).
+start_link(PoolName, ServerOpts, ChatterboxOpts, TransportOpts) ->
+    acceptor_pool:start_link({local, PoolName}, PoolName, ?MODULE,
+        [PoolName, ServerOpts, ChatterboxOpts, TransportOpts]).
 
 accept_socket(Pool, Socket, Acceptors) ->
     acceptor_pool:accept_socket(Pool, Socket, Acceptors).
@@ -17,7 +22,24 @@ accept_socket(Pool, Socket, Acceptors) ->
 pool_sockets(Pool) ->
     acceptor_pool:which_sockets(Pool).
 
-init([ServerOpts, ChatterboxOpts, TransportOpts]) ->
+%% return the number of active connection for the specified poolname
+connection_count(Pool) ->
+    case ets:lookup(?ACTIVE_CONNS_PER_POOL_TABLE, Pool) of
+        [{_, N}] -> N;
+        _ -> 0
+    end.
+
+%% inc the count of active connections for the specified poolname
+%% update_counter(Tab, Key, {Pos, Inc, Threshold, SetValue}, Default)
+inc_conn_count(Pool) ->
+    ets:update_counter(?ACTIVE_CONNS_PER_POOL_TABLE, Pool, {2, 1}, {Pool, 0}).
+
+%% dec the count of active connections for the specified poolname
+%% dont allow the count to drop below threshold of zero
+dec_conn_count(Pool) ->
+    ets:update_counter(?ACTIVE_CONNS_PER_POOL_TABLE, Pool, {2, -1, 0, 0}).
+
+init([PoolName, ServerOpts, ChatterboxOpts, TransportOpts]) ->
     {Transport, SslOpts} = case TransportOpts of
                                #{ssl := true,
                                  keyfile := KeyFile,
@@ -34,8 +56,9 @@ init([ServerOpts, ChatterboxOpts, TransportOpts]) ->
                                _ ->
                                    {gen_tcp, []}
                            end,
-
     Conn = #{id => grpcbox_acceptor,
-             start => {grpcbox_acceptor, {Transport, ServerOpts, ChatterboxOpts, SslOpts}, []},
+             start => {grpcbox_acceptor, {PoolName, Transport, ServerOpts, ChatterboxOpts, SslOpts}, []},
              grace => 5000},
     {ok, {#{intensity => 50, period => 2}, [Conn]}}.
+
+


### PR DESCRIPTION
Track number of connections per grpcbox pool and enforce a max limit if specified in the grpc server opts ( defined in sys.config ).  This implementation is self contained within grpcbox and does not require any changes to the acceptor pool dep.

TODO:

Whilst this is a much neater solution, it is not possible to make it work.  It relies on the acceptor pool callbacks to grpcbox_acceptor.  From these callbacks it is possible to determine when a pooled acceptor is allocated to an actual connection ( via acceptor_continue callback ) however it is not possible to distinguish a terminating raw acceptor from a terminating connected acceptor.  The  acceptor_terminate callback which is hit for any terminating connection has no state on whether the acceptor was allocated or not.  As such it is not possible to maintain an accurate counter of active connections



