### PR TITLE
API to open new channel

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         otp_version: ['24.1.2', '23.3.4.2', '22.3.4.20']
-        os: [ubuntu-latest]
+        os: [ubuntu-20.04]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,8 +15,8 @@ jobs:
 
     strategy:
       matrix:
-        otp_version: ['24.1.2', '23.3.4.2', '22.3.4.20']
-        os: [ubuntu-18.04]
+        otp_version: ['24.1.2', '23.3.4.2']
+        os: [ubuntu-20.04]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,7 @@ on:
       - 'master'
 
 jobs:
-  build23+:
+  build23andnewer:
     name: Test on OTP ${{ matrix.otp_version }} and ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
 
@@ -38,7 +38,7 @@ jobs:
       with:
         file: _build/test/covertool/grpcbox.covertool.xml
 
-  build22-:
+  build22andolder:
     name: Test on OTP ${{ matrix.otp_version }} and ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         otp_version: ['24.1.2', '23.3.4.2', '22.3.4.20']
-        os: [ubuntu-20.04]
+        os: [ubuntu-18.04]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,7 @@ on:
       - 'master'
 
 jobs:
-  build:
+  build23+:
     name: Test on OTP ${{ matrix.otp_version }} and ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
 
@@ -24,6 +24,36 @@ jobs:
     - uses: erlef/setup-beam@v1
       with:
         otp-version: ${{ matrix.otp_version }}
+
+    - name: Compile
+      run: rebar3 compile
+    - name: Tests
+      run: rebar3 ct --cover
+    - name: Dialyzer
+      run: rebar3 dialyzer
+    - name: Covertool
+      run: rebar3 covertool generate
+
+    - uses: codecov/codecov-action@v1
+      with:
+        file: _build/test/covertool/grpcbox.covertool.xml
+
+  build22-:
+    name: Test on OTP ${{ matrix.otp_version }} and ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        otp_version: ['22.3.4.20']
+        os: [ubuntu-20.04]
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - uses: erlef/setup-beam@v1
+      with:
+        otp-version: ${{ matrix.otp_version }}
+        rebar3-version: '3.18.0'
 
     - name: Compile
       run: rebar3 compile

--- a/src/grpcbox_channel_sup.erl
+++ b/src/grpcbox_channel_sup.erl
@@ -20,7 +20,8 @@ start_link() ->
     supervisor:start_link({local, ?SERVER}, ?MODULE, []).
 
 %% @doc Start a channel under the grpcbox channel supervisor.
--spec start_child(atom(), [grpcbox_channel:endpoint()], grpcbox_channel:options()) -> {ok, pid()}.
+-spec start_child(atom(), [grpcbox_channel:endpoint()], grpcbox_channel:options())
+                 -> supervisor:startchild_ret().
 start_child(Name, Endpoints, Options) ->
     supervisor:start_child(?SERVER, [Name, Endpoints, Options]).
 

--- a/src/grpcbox_client.erl
+++ b/src/grpcbox_client.erl
@@ -5,7 +5,9 @@
 
 -module(grpcbox_client).
 
--export([unary/6,
+-export([connect/3,
+        
+         unary/6,
          unary/5,
          stream/4,
          stream/5,
@@ -43,6 +45,9 @@
               unary_interceptor/0,
               stream_interceptor/0,
               interceptor/0]).
+
+connect(ChannelName, Endpoints, Options) ->
+    grpcbox_channel_sup:start_child(ChannelName, Endpoints, Options).
 
 get_channel(Options, Type) ->
     Channel = maps:get(channel, Options, default_channel),

--- a/test/grpcbox_SUITE.erl
+++ b/test/grpcbox_SUITE.erl
@@ -25,6 +25,7 @@ all() ->
      {group, concurrent},
      {group, negative_tests},
      {group, negative_ssl},
+     connect,
      initially_down_service,
      unary_interceptor,
      unary_client_interceptor,
@@ -117,6 +118,14 @@ end_per_group(_, _Config) ->
     application:stop(grpcbox),
     ok.
 
+init_per_testcase(connect, Config) ->
+    application:set_env(grpcbox, client, #{}),
+    application:set_env(grpcbox, servers, [#{grpc_opts => #{service_protos => [route_guide_pb],
+                                                            services => #{'routeguide.RouteGuide' =>
+                                                                              routeguide_route_guide}},
+                                             transport_opts => #{}}]),
+    application:ensure_all_started(grpcbox),
+    Config;
 init_per_testcase(initially_down_service, Config) ->
     application:set_env(grpcbox, client, #{channels => [{default_channel,
                                                          [{http, "localhost", 8080, []}], #{}}]}),
@@ -311,6 +320,11 @@ end_per_testcase(_, _Config) ->
     application:stop(grpcbox),
     ok.
 
+connect(_Config) ->
+    {ok, _} = grpcbox_client:connect(test_channel, [{http, "localhost", 8080, []}], #{sync_start => true}),
+    unary(test_channel).
+
+
 initially_down_service(_Config) ->
     Point = #{latitude => 409146138, longitude => -746188906},
     Ctx = ctx:with_deadline_after(ctx:new(), 5, second),
@@ -479,17 +493,15 @@ stats_handler(_Config) ->
     ?assert(maps:get(rpc_end, Stats) > maps:get(rpc_begin, Stats)).
 
 unary_no_auth(_Config) ->
-    unary(_Config).
+    unary().
 
-unary_authenticated(Config) ->
-    unary(Config).
+unary_authenticated(_Config) ->
+    unary().
 
 %% checks that no closed streams are left around after unary requests
-unary_garbage_collect_streams(Config) ->
-    unary(Config),
-
+unary_garbage_collect_streams(_Config) ->
+    unary(),
     ConnectionStreamSet = connection_stream_set(),
-
     ?assertEqual([], h2_stream_set:my_active_streams(ConnectionStreamSet)).
 
 client_stream_garbage_collect_streams(Config) ->
@@ -506,14 +518,14 @@ multiple_servers(_Config) ->
     ?assertMatch({ok, _}, grpcbox:start_server(#{grpc_opts => #{service_protos => [route_guide_pb],
                                                                 services => #{'routeguide.RouteGuide' => routeguide_route_guide}},
                                                  listen_opts => #{port => 8081}})),
-    unary(_Config),
-    unary(_Config).
+    unary(),
+    unary().
 
-unary_concurrent(Config) ->
+unary_concurrent(_Config) ->
     Nrs = lists:seq(1,100),
     ParentPid = self(),
     Pids = [spawn_link(fun() ->
-                               unary(Config),
+                               unary(),
                                ParentPid ! self()
                        end) || _ <- Nrs],
     unary_concurrent_wait_for_processes(Pids).
@@ -551,14 +563,6 @@ client_stream(_Config) ->
     ?assertMatch(ok, grpcbox_client:close_send(S)),
     ?assertMatch({ok, #{point_count := 2}}, grpcbox_client:recv_data(S)).
 %% TODO: add tests to ensure stream pids are gone and that accidental recvs and such after a close don't hang
-
-unary(_Channel) ->
-    Point = #{latitude => 409146138, longitude => -746188906},
-    {ok, Feature, _} = routeguide_route_guide_client:get_feature(Point),
-    ?assertEqual(#{location =>
-                       #{latitude => 409146138, longitude => -746188906},
-                   name =>
-                       <<"Berkshire Valley Management Area Trail, Jefferson, NJ, USA">>}, Feature).
 
 unary_client_interceptor(_Config) ->
     %% client side interceptor replaces the point with lat 30 and long 90
@@ -652,3 +656,20 @@ trace_to_trailer(Ctx, Message, _ServerInfo, Handler) ->
     Trailer = grpcbox_metadata:pairs([{<<"x-grpc-trace-id">>, BinTraceId}]),
     Ctx1 = grpcbox_stream:add_trailers(Ctx, Trailer),
     Handler(Ctx1, Message).
+
+unary() ->
+    Point = #{latitude => 409146138, longitude => -746188906},
+    {ok, Feature, _} = routeguide_route_guide_client:get_feature(Point),
+    ?assertEqual(#{location =>
+                       #{latitude => 409146138, longitude => -746188906},
+                   name =>
+                       <<"Berkshire Valley Management Area Trail, Jefferson, NJ, USA">>}, Feature).
+
+unary(Channel) ->
+    Point = #{latitude => 409146138, longitude => -746188906},
+    {ok, Feature, _} = routeguide_route_guide_client:get_feature(Point, #{channel => Channel}),
+    ?assertEqual(#{location =>
+                       #{latitude => 409146138, longitude => -746188906},
+                   name =>
+                       <<"Berkshire Valley Management Area Trail, Jefferson, NJ, USA">>}, Feature).
+


### PR DESCRIPTION
This PR adds `grpcbox_client:connect/3` to open a new connection/channel. The name, endpoints, and options are the same as the configuration tuple for `grpcbox` `client` `channels` in the `sys.config`.

This allows applications such as the helium packet router to use `grpcbox_client` to open connections to arbitrary endpoints rather than require all endpoints be known and configured at start up.