### PR TITLE
Async reply interface

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,14 +9,14 @@ on:
       - 'master'
 
 jobs:
-  build:
+  build23andnewer:
     name: Test on OTP ${{ matrix.otp_version }} and ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
 
     strategy:
       matrix:
-        otp_version: ['24.1.2', '23.3.4.2', '22.3.4.20']
-        os: [ubuntu-latest]
+        otp_version: ['24.1.2', '23.3.4.2']
+        os: [ubuntu-20.04]
 
     steps:
     - uses: actions/checkout@v2
@@ -24,6 +24,36 @@ jobs:
     - uses: erlef/setup-beam@v1
       with:
         otp-version: ${{ matrix.otp_version }}
+
+    - name: Compile
+      run: rebar3 compile
+    - name: Tests
+      run: rebar3 ct --cover
+    - name: Dialyzer
+      run: rebar3 dialyzer
+    - name: Covertool
+      run: rebar3 covertool generate
+
+    - uses: codecov/codecov-action@v1
+      with:
+        file: _build/test/covertool/grpcbox.covertool.xml
+
+  build22andolder:
+    name: Test on OTP ${{ matrix.otp_version }} and ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        otp_version: ['22.3.4.20']
+        os: [ubuntu-20.04]
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - uses: erlef/setup-beam@v1
+      with:
+        otp-version: ${{ matrix.otp_version }}
+        rebar3-version: '3.18.0'
 
     - name: Compile
       run: rebar3 compile

--- a/src/grpcbox_client_stream.erl
+++ b/src/grpcbox_client_stream.erl
@@ -13,6 +13,14 @@
 
 -include("grpcbox.hrl").
 
+-type client_stream_callback_data() :: term().
+
+-callback(init(pid(), non_neg_integer(), client_stream_callback_data()) -> {ok, client_stream_callback_data()}).
+-callback(handle_message(term(), client_stream_callback_data()) -> {ok, client_stream_callback_data()}).
+-callback(handle_headers(map(), client_stream_callback_data()) -> {ok, client_stream_callback_data()}).
+-callback(handle_trailers(binary(), term(), map(), client_stream_callback_data()) -> {ok, client_stream_callback_data()}).
+-callback(handle_eos(client_stream_callback_data()) -> {ok, client_stream_callback_data()}).
+
 -define(headers(Scheme, Host, Path, Encoding, MessageType, MD), [{<<":method">>, <<"POST">>},
                                                                  {<<":path">>, Path},
                                                                  {<<":scheme">>, Scheme},
@@ -76,7 +84,7 @@ send_request(Ctx, Channel, Path, Input, #grpcbox_def{service=Service,
             %% concurrent calls can't end up interleaving the sending of headers in such
             %% a way that a lower stream id's headers are sent after another's, which results
             %% in the server closing the connection when it gets them out of order
-            case h2_connection:new_stream(Conn, grpcbox_client_stream, [#{service => Service,
+            case h2_connection:new_stream(Conn, ?MODULE, [#{service => Service,
                                                                           marshal_fun => MarshalFun,
                                                                           unmarshal_fun => UnMarshalFun,
                                                                           path => Path,
@@ -136,69 +144,96 @@ metadata_headers(Ctx) ->
 
 %% callbacks
 
-init(_ConnectionPid, StreamId, [_, State=#{path := Path}]) ->
+init(ConnectionPid, StreamId, [_, State=#{path := Path, client_pid := ClientPid}]) ->
+    {CallbackModule, CallbackInitArgs} = maps:get(callback_module, State, {grpcbox_client_stream_callback, #{client_pid => ClientPid}}),
     _ = process_flag(trap_exit, true),
     Ctx1 = ctx:with_value(ctx:new(), grpc_client_method, Path),
     State1 = stats_handler(Ctx1, rpc_begin, {}, State),
-    {ok, State1#{stream_id => StreamId}};
+    {ok, CallbackData} = init_stream_callback(CallbackModule, CallbackInitArgs, ConnectionPid, StreamId), 
+    {ok, State1#{stream_id => StreamId, callback_module => {CallbackModule, CallbackInitArgs}, callback_data => CallbackData}};
 init(_, _, State) ->
     {ok, State}.
 
 on_receive_headers(H, State=#{resp_headers := _,
-                              ctx := Ctx,
-                              stream_id := StreamId,
-                              client_pid := Pid}) ->
+                              ctx := Ctx} = State) ->
     Status = proplists:get_value(<<"grpc-status">>, H, undefined),
     Message = proplists:get_value(<<"grpc-message">>, H, undefined),
     Metadata = grpcbox_utils:headers_to_metadata(H),
-    Pid ! {trailers, StreamId, {Status, Message, Metadata}},
+    State1 = handle_trailers_stream_callback(Status, Message, Metadata, State),
     Ctx1 = ctx:with_value(Ctx, grpc_client_status, grpcbox_utils:status_to_string(Status)),
-    {ok, State#{ctx => Ctx1,
+    {ok, State1#{ctx := Ctx1,
                 resp_trailers => H}};
-on_receive_headers(H, State=#{stream_id := StreamId,
-                              ctx := Ctx,
-                              client_pid := Pid}) ->
+on_receive_headers(H, State=#{ctx := Ctx} = State) ->
     Encoding = proplists:get_value(<<"grpc-encoding">>, H, identity),
     Metadata = grpcbox_utils:headers_to_metadata(H),
-    Pid ! {headers, StreamId, Metadata},
+
+    State1 = handle_headers_stream_callback(Metadata, State),
     %% TODO: better way to know if it is a Trailers-Only response?
     %% maybe chatterbox should include information about the end of the stream
     case proplists:get_value(<<"grpc-status">>, H, undefined) of
         undefined ->
-            {ok, State#{resp_headers => H,
+            {ok, State1#{resp_headers => H,
                         encoding => encoding_to_atom(Encoding)}};
         Status ->
             Message = proplists:get_value(<<"grpc-message">>, H, undefined),
-            Pid ! {trailers, StreamId, {Status, Message, Metadata}},
+            State2 = handle_trailers_stream_callback(Status, Message, Metadata, State),
             Ctx1 = ctx:with_value(Ctx, grpc_client_status, grpcbox_utils:status_to_string(Status)),
-            {ok, State#{resp_headers => H,
+            {ok, State2#{resp_headers => H,
                         ctx => Ctx1,
                         status => Status,
                         encoding => encoding_to_atom(Encoding)}}
     end.
 
-on_receive_data(Data, State=#{stream_id := StreamId,
-                              client_pid := Pid,
-                              buffer := Buffer,
-                              encoding := Encoding,
-                              unmarshal_fun := UnmarshalFun}) ->
+on_receive_data(Data, State=#{buffer := Buffer,
+                              encoding := Encoding} = State) ->
     {Remaining, Messages} = grpcbox_frame:split(<<Buffer/binary, Data/binary>>, Encoding),
-    [Pid ! {data, StreamId, UnmarshalFun(Message)} || Message <- Messages],
-    {ok, State#{buffer => Remaining}};
+    State1 = handle_message_stream_callback(Messages, State),
+    {ok, State1#{buffer => Remaining}};
 on_receive_data(_Data, State) ->
     {ok, State}.
 
-on_end_stream(State=#{stream_id := StreamId,
-                      ctx := Ctx,
-                      client_pid := Pid}) ->
-    Pid ! {eos, StreamId},
-    State1 = stats_handler(Ctx, rpc_end, {}, State),
-    {ok, State1}.
+on_end_stream(State=#{ctx := Ctx}) ->
+    State1 = handle_eos_stream_callback(State),
+    State2 = stats_handler(Ctx, rpc_end, {}, State1),
+    {ok, State2}.
 
 handle_info(_, State) ->
     State.
 
 %%
+
+init_stream_callback(CallbackModule, CallbackInitArgs, ConnectionPid, StreamId) ->
+    CallbackModule:init(ConnectionPid, StreamId, CallbackInitArgs).
+
+handle_message_stream_callback(Messages, State) ->
+    #{unmarshal_fun := UnmarshalFun,
+      callback_module := {CallbackModule, _},
+      callback_data := CallbackData} = State,
+    CallbackData1 = lists:foldl(
+                        fun(M, D) ->
+                            {ok, D1} = CallbackModule:handle_message(UnmarshalFun(M), D),
+                            D1
+                        end, CallbackData, Messages),
+    State#{callback_data := CallbackData1}.
+
+handle_trailers_stream_callback(Status, Message, Metadata, State) ->
+    #{callback_module := {CallbackModule, _},
+      callback_data := CallbackData} = State,
+    {ok, NewCallbackData} = CallbackModule:handle_trailers(Status, Message, Metadata, CallbackData),
+    State#{callback_data := NewCallbackData}.
+
+handle_headers_stream_callback(Metadata, State) ->
+    #{callback_module := {CallbackModule, _},
+      callback_data := CallbackData} = State,
+    {ok, NewCallbackData} = CallbackModule:handle_headers(Metadata, CallbackData),
+    State#{callback_data := NewCallbackData}.
+
+handle_eos_stream_callback(State) ->
+    #{callback_module := {CallbackModule, _},
+      callback_data := CallbackData} = State,
+    {ok, NewCallbackData} = CallbackModule:handle_eos(CallbackData),
+    State#{callback_data := NewCallbackData}.
+
 
 stats_handler(Ctx, _, _, State=#{stats_handler := undefined}) ->
     State#{ctx => Ctx};

--- a/src/grpcbox_client_stream_callback.erl
+++ b/src/grpcbox_client_stream_callback.erl
@@ -1,0 +1,42 @@
+-module(grpcbox_client_stream_callback).
+
+-behaviour(grpcbox_client_stream).
+
+-export([
+    init/3,
+    handle_message/2,
+    handle_headers/2,
+    handle_trailers/4,
+    handle_eos/1
+]).
+
+-type stream_id() :: non_neg_integer().
+-type callback_data() :: #{client_pid => pid(), stream_id => stream_id()}.
+
+-spec init(pid(), stream_id(), callback_data()) -> {ok, callback_data()}.
+init(_ConnectionPid, StreamId, #{client_pid := ClientPid}) ->
+    {ok, #{client_pid => ClientPid, stream_id => StreamId}}.
+
+-spec handle_message(term(), callback_data()) -> {ok, callback_data()}.
+handle_message(UnmarshalledMessage, CBData) ->
+    #{client_pid := ClientPid, stream_id := StreamId} = CBData,
+    ClientPid ! {data, StreamId, UnmarshalledMessage},
+    {ok, CBData}.
+
+-spec handle_headers(map(), callback_data()) -> {ok, callback_data()}.
+handle_headers(Metadata, CBData) ->
+    #{client_pid := ClientPid, stream_id := StreamId} = CBData,
+    ClientPid ! {headers, StreamId, Metadata},
+    {ok, CBData}.
+
+-spec handle_trailers(binary(), term(), map(), callback_data()) -> {ok, callback_data()}.
+handle_trailers(Status, Message, Metadata, CBData) ->
+    #{client_pid := ClientPid, stream_id := StreamId} = CBData,
+    ClientPid ! {trailers, StreamId, {Status, Message, Metadata}},
+    {ok, CBData}.
+
+-spec handle_eos(callback_data()) -> {ok, callback_data()}.
+handle_eos(CBData) ->
+    #{client_pid := ClientPid, stream_id := StreamId} = CBData,
+    ClientPid ! {eos, StreamId},
+    {ok, CBData}.

--- a/test/grpcbox_SUITE.erl
+++ b/test/grpcbox_SUITE.erl
@@ -32,6 +32,7 @@ all() ->
      stream_interceptor,
      bidirectional,
      client_stream,
+     client_stream_callback,
      client_stream_garbage_collect_streams,
      compression,
      stats_handler,
@@ -203,6 +204,14 @@ init_per_testcase(bidirectional, Config) ->
     application:ensure_all_started(grpcbox),
     Config;
 init_per_testcase(client_stream, Config) ->
+    application:set_env(grpcbox, client, #{channels => [{default_channel,
+                                                         [{http, "localhost", 8080, []}], #{}}]}),
+    application:set_env(grpcbox, servers,
+                        [#{grpc_opts => #{service_protos => [route_guide_pb],
+                                          services => #{'routeguide.RouteGuide' => routeguide_route_guide}}}]),
+    application:ensure_all_started(grpcbox),
+    Config;
+init_per_testcase(client_stream_callback, Config) ->
     application:set_env(grpcbox, client, #{channels => [{default_channel,
                                                          [{http, "localhost", 8080, []}], #{}}]}),
     application:set_env(grpcbox, servers,
@@ -551,6 +560,20 @@ client_stream(_Config) ->
     ?assertMatch(ok, grpcbox_client:close_send(S)),
     ?assertMatch({ok, #{point_count := 2}}, grpcbox_client:recv_data(S)).
 %% TODO: add tests to ensure stream pids are gone and that accidental recvs and such after a close don't hang
+
+client_stream_callback(_Config) ->
+    Ref = make_ref(),
+    {ok, S} = routeguide_route_guide_client:record_route(ctx:new(), #{callback_module => {test_client_stream_callback, #{ref => Ref, reply_to => self()}}}),
+    ok = grpcbox_client:send(S, #{latitude => 409146138, longitude => -746188906}),
+    ok = grpcbox_client:send(S, #{latitude => 234818903, longitude => -823423910}),
+    ?assertMatch(ok, grpcbox_client:close_send(S)),
+    receive
+        {data, R, Data} ->
+            ?assertEqual(Ref, R),
+            ?assertMatch(#{point_count := 2}, Data)
+    after 1000 ->
+        ?assert(timeout)
+    end.
 
 unary(_Channel) ->
     Point = #{latitude => 409146138, longitude => -746188906},

--- a/test/test_client_stream_callback.erl
+++ b/test/test_client_stream_callback.erl
@@ -1,4 +1,4 @@
--module(grpcbox_client_stream_callback).
+-module(test_client_stream_callback).
 
 -behaviour(grpcbox_client_stream).
 
@@ -11,32 +11,32 @@
 ]).
 
 -type stream_id() :: non_neg_integer().
--type callback_data() :: #{client_pid => pid(), stream_id => stream_id()}.
+-type callback_data() :: #{reply_to => pid(), ref => reference()}.
 
 -spec init(pid(), stream_id(), term()) -> {ok, callback_data()}.
-init(_ConnectionPid, StreamId, #{client_pid := ClientPid}) ->
-    {ok, #{client_pid => ClientPid, stream_id => StreamId}}.
+init(_ConnectionPid, _StreamId, #{reply_to := Pid, ref := Ref}) ->
+    {ok, #{reply_to => Pid, ref => Ref}}.
 
 -spec handle_message(term(), callback_data()) -> {ok, callback_data()}.
 handle_message(UnmarshalledMessage, CBData) ->
-    #{client_pid := ClientPid, stream_id := StreamId} = CBData,
-    ClientPid ! {data, StreamId, UnmarshalledMessage},
+    #{reply_to := Pid, ref := Ref} = CBData,
+    Pid ! {data, Ref, UnmarshalledMessage},
     {ok, CBData}.
 
 -spec handle_headers(map(), callback_data()) -> {ok, callback_data()}.
 handle_headers(Metadata, CBData) ->
-    #{client_pid := ClientPid, stream_id := StreamId} = CBData,
-    ClientPid ! {headers, StreamId, Metadata},
+    #{reply_to := Pid, ref := Ref} = CBData,
+    Pid ! {headers, Ref, Metadata},
     {ok, CBData}.
 
 -spec handle_trailers(binary(), term(), map(), callback_data()) -> {ok, callback_data()}.
 handle_trailers(Status, Message, Metadata, CBData) ->
-    #{client_pid := ClientPid, stream_id := StreamId} = CBData,
-    ClientPid ! {trailers, StreamId, {Status, Message, Metadata}},
+    #{reply_to := Pid, ref := Ref} = CBData,
+    Pid ! {trailers, Ref, {Status, Message, Metadata}},
     {ok, CBData}.
 
 -spec handle_eos(callback_data()) -> {ok, callback_data()}.
 handle_eos(CBData) ->
-    #{client_pid := ClientPid, stream_id := StreamId} = CBData,
-    ClientPid ! {eos, StreamId},
+    #{reply_to := Pid, ref := Ref} = CBData,
+    Pid ! {eos, Ref},
     {ok, CBData}.


### PR DESCRIPTION
Adds a callback module for `grpc` streams to return replies. Refactors the existing code to use the new callback module. This provides an example of how to implement a callback module and allows for reuse of the existing `ct` tests.

### Flow for replies
1. Generated RPC function calls `grpc_client:stream`, as in: 
```
list_features(Ctx, Input, Options) ->
    grpcbox_client:stream(Ctx, <<"/routeguide.RouteGuide/ListFeatures">>, Input, ?DEF(rectangle, feature, <<"routeguide.Rectangle">>), Options).
```
2. `grpcbox_client:stream` calls `grpcbox_client_stream:new_stream`
3. `grpcbox_client_stream:new_stream` calls `h2_connection:new_stream` using `grpcbox_client_stream` as the callback module
4. `h2_connection` calls `grpcbox_client_stream:init` to initialize the `grpcbox`-level state
5. `grpcbox_client_stream:init` captures the callback module for the application-layer (hpr) and saves it in the `grpcbox`-level state; If none is given we use a "default" callback module (`grpcbox_client_stream_callback`) which replicates the original synchronous functionality.
6. When header, trailer, or data arrives `h2_connection` calls `grpcbox_client_stream:on_receive_headers` (for headers and trailers) or `grpcbox_client_stream:on_receive_data` (for data)
7. `on_receive_headers` and `on_receive_data` call the appropriate callback function from the saved application-layer callback module; in `grpcbox_client_stream_callback` this sends messages to the client pid similar to the original code; `grpcbox_client:recv_` functions `receive` these messages

### Usage
To use a different application-level callback function, applications can set the `callback_module` option with a `{Module, InitArg}` tuple. When `h2_connection` initializes the `grpcbox`-level state, `grpcbox_client_stream:init` calls `Module:init(ConnectionPid, StreamId, InitArg)`.

The `grpcbox`-level callbacks `grpcbox_client_stream:on_receive_headers` and `grpcbox_client_stream:on_receive_data` call the the application-level callbacks in `Module`:
- `on_receive_headers` calls `Module:handle_headers` and/or `Module:handle_trailers` as appropriate.
- `on_receive_data` calls `Module:handle_message`
- `on_end_stream` calls `Module:handle_eos`