### PR TITLE
removing direct h2 stop calls; handling ok-tuple in fold

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        otp_version: ['24.1.2', '23.3.4.2']
+        otp_version: ['24.3.4.6', '23.3.4.18']
         os: [ubuntu-20.04]
 
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,8 +15,8 @@ jobs:
 
     strategy:
       matrix:
-        otp_version: ['24.1.2', '23.3.4.2', '22.3.4.20']
-        os: [ubuntu-latest]
+        otp_version: ['24.1.2', '23.3.4.2']
+        os: [ubuntu-20.04]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
This change should be discussed as it removes a fix for a prior issue in the helium validator grpc server streams wherein stopped streams were leaking processes, causing performance problems for the host, i.e. by explicitly stopping the h2 stream directly whenever the stream grpc stream has been directed to stop (with the `end_stream/3` function).

However, in testing the scenario where the client requests to stream a large but finite dataset over the connection, which should terminate when the results have all been sent, I found this early termination of the h2 stream cut off the connection too early, causing significant results to be dropped from the stream (17-20k gateway info results when explicitly terminating the connection vs. 900+k results when allowing it to close itself).

The other included fix adds handling of the `handle_message/2` to return either a stream `state{}` record _or_ a `{ok, state{}}` tuple, which are both options for a successful return from that function. This was causing a noisy if not disruptive exception to be raised that was being silently swallowed by the `try/catch` it's called from.