### PR TITLE
reinstate stop stream calls when handling stop directive from handler

### DIFF
--- a/src/grpcbox_stream.erl
+++ b/src/grpcbox_stream.erl
@@ -206,10 +206,12 @@ handle_streams(Ref, State=#state{full_method=FullMethod,
             {ok, State3};
         {stop, State1} ->
             {ok, State2} = end_stream(State1),
+            _ = stop_stream(?STREAM_CLOSED, State2),
             {ok, State2};
         {stop, Response, State1} ->
             State2 = send(false, Response, State1),
             {ok, State3} = end_stream(State2),
+            _ = stop_stream(?STREAM_CLOSED, State3),
             {ok, State3};
         E={grpc_error, _} ->
             throw(E);
@@ -238,10 +240,12 @@ handle_streams(Ref, State=#state{full_method=FullMethod,
             send(false, Response, State1);
         {stop, State1} ->
             {ok, State2} = end_stream(State1),
+            _ = stop_stream(?STREAM_CLOSED, State2),
             {ok, State2};
         {stop, Response, State1} ->
             State2 = send(false, Response, State1),
             {ok, State3} = end_stream(State2),
+            _ = stop_stream(?STREAM_CLOSED, State3),
             {ok, State3};
         {grpc_error, {Status, Message}} ->
             {ok, State1} = end_stream(Status, Message, State),


### PR DESCRIPTION
This fixes a previously fixed stream process leak that was later removed with https://github.com/novalabsxyz/grpcbox/pull/17

